### PR TITLE
Fix cache fields data

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Before use, put these settings into munin configuration.
     * in the case of creating file per plugins.<br />
       `/etc/munin/plugin-conf.d/elasticsearch`
 
-##### example of minimam configuration<br />
+##### example of minimal configuration<br />
 
 `elasticsearch_open_files` has required root privilege to read under the `/proc`.
 

--- a/elasticsearch_cache
+++ b/elasticsearch_cache
@@ -57,9 +57,11 @@ my %out = (field_size => 0, filter_size => 0);
 
 foreach my $full_node_name (keys %{$data->{nodes}}) {
     next unless $t_data->{nodes}{$full_node_name};
-    if (defined($t_data->{nodes}{$full_node_name}{indices}{cache})) {
-        $out{field_size} += $t_data->{nodes}{$full_node_name}{indices}{cache}{field_size_in_bytes};
-        $out{filter_size} += $t_data->{nodes}{$full_node_name}{indices}{cache}{filter_size_in_bytes};
+    if (defined($t_data->{nodes}{$full_node_name}{indices}{fielddata})) {
+        $out{field_size} += $t_data->{nodes}{$full_node_name}{indices}{fielddata}{memory_size_in_bytes};
+    }
+    if (defined($t_data->{nodes}{$full_node_name}{indices}{filter_cache})) {
+        $out{filter_size} += $t_data->{nodes}{$full_node_name}{indices}{filter_cache}{memory_size_in_bytes};
     }
 }
 if ($ARGV[0] and $ARGV[0] eq 'config') {


### PR DESCRIPTION
In Elasticsearch 1.3.x  and 1.4.x the cache field information moved to
`[full_node_name][indices][fielddata][memory_size_in_bytes]`.

This PR adjusts the `elasticsearch_cache` script accordingly and fixes a small typo in the README file.
