### PR TITLE
Allow for overriding user and data directory

### DIFF
--- a/elasticsearch_open_files
+++ b/elasticsearch_open_files
@@ -17,7 +17,12 @@ if [ "$1" = "config" ]; then
         exit 0
 fi
 
-PID=`ps -u elasticsearch -opid,comm | grep java | awk '{ print $1 }'`
+
+if [ -z "${es_user}" ]; then
+  es_user="elasticsearch"
+fi
+
+PID=`ps -u $es_user -opid,comm | grep java | awk '{ print $1 }'`
 VALUE=`ls /proc/$PID/fd/ | wc | awk '{ print $1 }'`
 MAX_VALUE=`grep 'Max open files' /proc/$PID/limits | awk '{ print $5 }'`
 echo "used.value $VALUE"

--- a/elasticsearch_translog_size
+++ b/elasticsearch_translog_size
@@ -18,7 +18,17 @@ if [ "$1" = "config" ]; then
         exit 0
 fi
 
-DIR=`ps -u elasticsearch -opid,command |tail -1| perl -ne 'print $1 if(/-Des.default.path.data=([\w\/]+)/)'`
+if [ -z "${es_user}" ]; then
+  es_user="elasticsearch"
+fi
+
+
+if [ -n "${data_dir}" ]; then
+    DIR=${data_dir}
+else
+    DIR=`ps -u $es_user -opid,command |tail -1| perl -ne 'print $1 if(/-Des.default.path.data=([\w\/]+)/)'`
+fi
+
 NUMBER=`ls $DIR/*/nodes/0/indices/*/*/translog/* | wc -l`
 SIZE=`du -s $DIR/*/nodes/0/indices/*/*/translog/* | awk '{sum+=$1};END{print sum}'`
 echo "number.value $NUMBER"


### PR DESCRIPTION
This allows for overriding the user that runs elasticsearch (needed for the `ps` grep stuff so it works for users other than `elasticsearch`) and for overriding the directory where the index data is kept.
Syntax in the config file is `env.es_user <<username>>`.

Running elasticsearch 1.3.x and 1.4.x, the grep for `es.default.path.data` didn't yield anything so I added an option to allow for overriding the data directory in the config via eg. `env.data_dir /data/index/`
