### PR TITLE
Fix incorrect values in index operations

### DIFF
--- a/elasticsearch_cache
+++ b/elasticsearch_cache
@@ -1,28 +1,28 @@
 #!/usr/bin/env perl
 
-# Parameters supported:       
-#                             
-# config                      
-# autoconf                    
-#                             
-# Magic markers:              
-#%# family=auto               
-#%# capabilities=autoconf     
-                              
-use strict;                   
-use warnings;                 
-use LWP;                      
-use JSON qw/decode_json/;     
-                              
-=head1 NAME                   
-                              
+# Parameters supported:
+#
+# config
+# autoconf
+#
+# Magic markers:
+#%# family=auto
+#%# capabilities=autoconf
+
+use strict;
+use warnings;
+use LWP;
+use JSON qw/decode_json/;
+
+=head1 NAME
+
 elasticsearch_cache - A munin plugin that collects cache stats of your elasticsearch instances
-                              
-=head1 APPLICABLE SYSTEMS     
-                              
-elasticsearch                 
-                              
-=head1 CONFIGURATION          
+
+=head1 APPLICABLE SYSTEMS
+
+elasticsearch
+
+=head1 CONFIGURATION
 
 None
 

--- a/elasticsearch_cache
+++ b/elasticsearch_cache
@@ -20,7 +20,7 @@ elasticsearch_cache - A munin plugin that collects cache stats of your elasticse
 
 =head1 APPLICABLE SYSTEMS
 
-elasticsearch
+Elasticsearch
 
 =head1 CONFIGURATION
 

--- a/elasticsearch_cluster_shards
+++ b/elasticsearch_cluster_shards
@@ -1,19 +1,19 @@
 #!/usr/bin/env perl
 
-# Parameters supported:       
-#                             
-# config                      
-# autoconf                    
-#                             
-# Magic markers:              
-#%# family=auto               
-#%# capabilities=autoconf     
-                              
-use strict;                   
-use warnings;                 
-use LWP;                      
-use JSON qw/decode_json/;     
-                              
+# Parameters supported:
+#
+# config
+# autoconf
+#
+# Magic markers:
+#%# family=auto
+#%# capabilities=autoconf
+
+use strict;
+use warnings;
+use LWP;
+use JSON qw/decode_json/;
+
 =head1 NAME
 
 elasticsearch_cluster_shards - A munin plugin that collects shard stats of your elasticsearch instances

--- a/elasticsearch_cluster_shards
+++ b/elasticsearch_cluster_shards
@@ -20,7 +20,7 @@ elasticsearch_cluster_shards - A munin plugin that collects shard stats of your 
 
 =head1 APPLICABLE SYSTEMS
 
-elasticsearch
+Elasticsearch
 
 =head1 CONFIGURATION
 

--- a/elasticsearch_docs
+++ b/elasticsearch_docs
@@ -20,7 +20,7 @@ elasticsearch_docs - A munin plugin that collects document stats of your elastic
 
 =head1 APPLICABLE SYSTEMS
 
-elasticsearch
+Elasticsearch
 
 =head1 CONFIGURATION
 

--- a/elasticsearch_docs
+++ b/elasticsearch_docs
@@ -1,25 +1,25 @@
 #!/usr/bin/env perl
 
-# Parameters supported:       
-#                             
-# config                      
-# autoconf                    
-#                             
-# Magic markers:              
-#%# family=auto               
-#%# capabilities=autoconf     
-                              
-use strict;                   
-use warnings;                 
-use LWP;                      
-use JSON qw/decode_json/;     
-                              
-=head1 NAME                   
-                              
+# Parameters supported:
+#
+# config
+# autoconf
+#
+# Magic markers:
+#%# family=auto
+#%# capabilities=autoconf
+
+use strict;
+use warnings;
+use LWP;
+use JSON qw/decode_json/;
+
+=head1 NAME
+
 elasticsearch_docs - A munin plugin that collects document stats of your elasticsearch instances
-                              
-=head1 APPLICABLE SYSTEMS     
-                              
+
+=head1 APPLICABLE SYSTEMS
+
 elasticsearch
 
 =head1 CONFIGURATION

--- a/elasticsearch_gc_time
+++ b/elasticsearch_gc_time
@@ -20,7 +20,7 @@ elasticsearch_gc_time - A munin plugin that collects garbage collection time sta
 
 =head1 APPLICABLE SYSTEMS
 
-ElasticSearch
+Elasticsearch
 
 =head1 CONFIGURATION
 

--- a/elasticsearch_gc_time
+++ b/elasticsearch_gc_time
@@ -65,7 +65,7 @@ foreach my $full_node_name (keys %{$data->{nodes}}) {
     }
 }
 if ($ARGV[0] and $ARGV[0] eq 'config') {
-    print "graph_title ElasticSearch gc time\n";
+    print "graph_title Elasticsearch gc time\n";
     print "graph_category elasticsearch\n";
     print "graph_vlabel miliseconds\n";
 

--- a/elasticsearch_index_size
+++ b/elasticsearch_index_size
@@ -20,7 +20,7 @@ elasticsearch_index_size - A munin plugin that collects index size of your elast
 
 =head1 APPLICABLE SYSTEMS
 
-elasticSearch
+Elasticsearch
 
 =head1 CONFIGURATION
 

--- a/elasticsearch_index_size
+++ b/elasticsearch_index_size
@@ -62,7 +62,7 @@ foreach my $full_node_name (keys %{$data->{nodes}}) {
 }
 if ($ARGV[0] and $ARGV[0] eq 'config') {
     print "graph_args --base 1024\n";
-    print "graph_title elasticsearch indexes\n";
+    print "graph_title Elasticsearch indexes\n";
     print "graph_category elasticsearch\n";
     print "graph_vlabel Bytes\n";
 

--- a/elasticsearch_index_total
+++ b/elasticsearch_index_total
@@ -57,10 +57,10 @@ my %out;
 
 foreach my $full_node_name (keys %{$data->{nodes}}) {
     next unless $t_data->{nodes}{$full_node_name};
-    $out{index} = $t_data->{nodes}{$full_node_name}{indices}{indexing}{index_total};
-    $out{get} = $t_data->{nodes}{$full_node_name}{indices}{get}{total};
-    $out{search} = $t_data->{nodes}{$full_node_name}{indices}{search}{query_total};
-    $out{delete} = $t_data->{nodes}{$full_node_name}{indices}{indexing}{delete_total};
+    $out{index} += $t_data->{nodes}{$full_node_name}{indices}{indexing}{index_total};
+    $out{get} += $t_data->{nodes}{$full_node_name}{indices}{get}{total};
+    $out{search} += $t_data->{nodes}{$full_node_name}{indices}{search}{query_total};
+    $out{delete} += $t_data->{nodes}{$full_node_name}{indices}{indexing}{delete_total};
 }
 if ($ARGV[0] and $ARGV[0] eq 'config') {
     print "graph_title elasticsearch index operations\n";

--- a/elasticsearch_index_total
+++ b/elasticsearch_index_total
@@ -20,7 +20,7 @@ elasticsearch_index_total - A munin plugin that collects stats about the index t
 
 =head1 APPLICABLE SYSTEMS
 
-elasticsearch
+Elasticsearch
 
 =head1 CONFIGURATION
 

--- a/elasticsearch_index_total
+++ b/elasticsearch_index_total
@@ -67,23 +67,23 @@ if ($ARGV[0] and $ARGV[0] eq 'config') {
     print "graph_category elasticsearch\n";
     print "graph_args --base 1000 -l 0\n";
     print "graph_vlabel Operations per second\n";
-            
+
     print "graph_order index get search delete\n";
     print "index.label index\n";
     print "index.type DERIVE\n";
     print "index.min 0\n";
     print "index.draw LINE2\n";
-        
+
     print "get.label get\n";
     print "get.type DERIVE\n";
     print "get.min 0\n";
     print "get.draw LINE2\n";
-            
+
     print "search.label search\n";
     print "search.type DERIVE\n";
     print "search.min 0\n";
     print "search.draw LINE2\n";
-            
+
     print "delete.label delete\n";
     print "delete.type DERIVE\n";
     print "delete.min 0\n";

--- a/elasticsearch_index_total
+++ b/elasticsearch_index_total
@@ -63,7 +63,7 @@ foreach my $full_node_name (keys %{$data->{nodes}}) {
     $out{delete} += $t_data->{nodes}{$full_node_name}{indices}{indexing}{delete_total};
 }
 if ($ARGV[0] and $ARGV[0] eq 'config') {
-    print "graph_title elasticsearch index operations\n";
+    print "graph_title Elasticsearch index operations\n";
     print "graph_category elasticsearch\n";
     print "graph_args --base 1000 -l 0\n";
     print "graph_vlabel Operations per second\n";

--- a/elasticsearch_jvm_memory
+++ b/elasticsearch_jvm_memory
@@ -64,7 +64,7 @@ foreach my $full_node_name (keys %{$data->{nodes}}) {
 }
 if ($ARGV[0] and $ARGV[0] eq 'config') {
     print "graph_args --base 1024\n";
-    print "graph_title elasticsearch JVM memory usage\n";
+    print "graph_title Elasticsearch JVM memory usage\n";
     print "graph_category elasticsearch\n";
     print "graph_vlabel Bytes\n";
 

--- a/elasticsearch_jvm_memory
+++ b/elasticsearch_jvm_memory
@@ -20,7 +20,7 @@ elasticsearch_jvm_memory - A munin plugin that collects JVM memory stats from th
 
 =head1 APPLICABLE SYSTEMS
 
-elasticsearch
+Elasticsearch
 
 =head1 CONFIGURATION
 

--- a/elasticsearch_jvm_memory
+++ b/elasticsearch_jvm_memory
@@ -1,27 +1,27 @@
 #!/usr/bin/env perl
 
-# Parameters supported:       
-#                             
-# config                      
-# autoconf                    
-#                             
-# Magic markers:              
-#%# family=auto               
-#%# capabilities=autoconf     
-                              
-use strict;                   
-use warnings;                 
-use LWP;                      
-use JSON qw/decode_json/;     
-                              
-=head1 NAME                   
-                              
+# Parameters supported:
+#
+# config
+# autoconf
+#
+# Magic markers:
+#%# family=auto
+#%# capabilities=autoconf
+
+use strict;
+use warnings;
+use LWP;
+use JSON qw/decode_json/;
+
+=head1 NAME
+
 elasticsearch_jvm_memory - A munin plugin that collects JVM memory stats from the JVM of your elasticsearch instances
-                              
-=head1 APPLICABLE SYSTEMS     
-                              
-elasticsearch                 
-                              
+
+=head1 APPLICABLE SYSTEMS
+
+elasticsearch
+
 =head1 CONFIGURATION
 
 None

--- a/elasticsearch_jvm_pools_size
+++ b/elasticsearch_jvm_pools_size
@@ -72,7 +72,7 @@ foreach my $full_node_name (keys %{$data->{nodes}}) {
     }
 }
 if ($ARGV[0] and $ARGV[0] eq 'config') {
-    print "graph_title ElasticSearch jvm pools size\n";
+    print "graph_title Elasticsearch jvm pools size\n";
     print "graph_category elasticsearch\n";
     print "graph_vlabel bytes\n";
 

--- a/elasticsearch_jvm_pools_size
+++ b/elasticsearch_jvm_pools_size
@@ -20,7 +20,7 @@ elasticsearch_jvm_pools_size - A munin plugin that collects jvm pools size stats
 
 =head1 APPLICABLE SYSTEMS
 
-ElasticSearch
+Elasticsearch
 
 =head1 CONFIGURATION
 

--- a/elasticsearch_jvm_threads
+++ b/elasticsearch_jvm_threads
@@ -63,7 +63,7 @@ foreach my $full_node_name (keys %{$data->{nodes}}) {
     }
 }
 if ($ARGV[0] and $ARGV[0] eq 'config') {
-    print "graph_title elasticsearch JVM threads\n";
+    print "graph_title Elasticsearch JVM threads\n";
     print "graph_category elasticsearch\n";
     print "graph_scale no\n";
 

--- a/elasticsearch_jvm_threads
+++ b/elasticsearch_jvm_threads
@@ -20,7 +20,7 @@ elasticsearch_jvm_threads - A munin plugin that collects stats from the JVM of y
 
 =head1 APPLICABLE SYSTEMS
 
-elasticsearch
+Elasticsearch
 
 =head1 CONFIGURATION
 

--- a/elasticsearch_open_files
+++ b/elasticsearch_open_files
@@ -15,14 +15,14 @@ use LWP;
 use JSON qw/decode_json/;
 
 =head1 NAME
-                              
+
 elasticsearch_open_files - A munin plugin that collects the number of open files in your elasticsearch instances
-                              
+
 =head1 APPLICABLE SYSTEMS
-                              
-elasticsearch                 
-                              
-=head1 CONFIGURATION          
+
+elasticsearch
+
+=head1 CONFIGURATION
 
 None
 

--- a/elasticsearch_open_files
+++ b/elasticsearch_open_files
@@ -71,7 +71,7 @@ my %out = (
 );
 
 if ($ARGV[0] and $ARGV[0] eq 'config') {
-    print "graph_title elasticsearch open files\n";
+    print "graph_title Elasticsearch open files\n";
     print "graph_args --base 1000 -l 0\n";
     print "graph_vlabel number of open files\n";
     print "graph_category elasticsearch\n";

--- a/elasticsearch_open_files
+++ b/elasticsearch_open_files
@@ -20,7 +20,7 @@ elasticsearch_open_files - A munin plugin that collects the number of open files
 
 =head1 APPLICABLE SYSTEMS
 
-elasticsearch
+Elasticsearch
 
 =head1 CONFIGURATION
 


### PR DESCRIPTION
Fix incorrect values in index operations with some minor changes.
1. Fix incorrect values by sum all values in nodes
2. Captialize Elasticsearch for cosistency
3. Remove trailing spaces
